### PR TITLE
Fixed a recursive loop within the checkCompressedImageSize method

### DIFF
--- a/src/ngx-pica.service.ts
+++ b/src/ngx-pica.service.ts
@@ -222,9 +222,7 @@ export class NgxPicaService {
 
             if (step > this.MAX_STEPS) {
                 reject(NgxPicaErrorType.NOT_BE_ABLE_TO_COMPRESS_ENOUGH);
-            }
-
-            if (this.bytesToMB(blob.size) < sizeInMB) {
+            } else if (this.bytesToMB(blob.size) < sizeInMB) {
                 resolve(blob);
             } else {
                 const newQuality: number = quality - (quality * 0.1);


### PR DESCRIPTION
If an image can't be compressed enough i.e ([this image](https://imgur.com/gallery/ScunCtz)) the service will reject and resolve a promise at the same time.