### PR TITLE
Do not use File constructor

### DIFF
--- a/src/ngx-pica.service.ts
+++ b/src/ngx-pica.service.ts
@@ -247,7 +247,7 @@ export class NgxPicaService {
     }
 
     private blobToFile(blob: Blob, name: string, type: string, lastModified: number): File {
-        return new File([blob], name, {type: type, lastModified: lastModified});
+        return Object.assign(new Blob([blob], { type: type }), { name: name, lastModified: lastModified });
     }
 
     private bytesToMB(bytes: number) {


### PR DESCRIPTION
The `File` constructor is not supported under Edge or in iOS WebViews.

This directly adds the `File` fields to a copy of the blob.