### PR TITLE
Update ngx-pica-exif.service.ts

### DIFF
--- a/projects/digitalascetic/ngx-pica/src/lib/ngx-pica-exif.service.ts
+++ b/projects/digitalascetic/ngx-pica/src/lib/ngx-pica-exif.service.ts
@@ -11,7 +11,7 @@ export class NgxPicaExifService {
                 const allExifMetaData = EXIF.getAllTags(image),
                     exifOrientation = allExifMetaData.Orientation;
 
-                if (exifOrientation) {
+                if (exifOrientation && exifOrientation !== 1) {
 
                     if (!/^[1-8]$/.test(exifOrientation)) {
                         throw new Error('orientation should be [1-8]');


### PR DESCRIPTION
canvas.toDataURL() was called even if Rotation was 1, which led to significant performance issues for BIG NON-ROTATED images.